### PR TITLE
Fix: 1.21.5 Entity Variant Condition

### DIFF
--- a/data/minecraft/loot_table/entities/axolotl.json
+++ b/data/minecraft/loot_table/entities/axolotl.json
@@ -212,9 +212,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:axolotl",
-                  "variant": "blue"
+                "components": {
+                  "minecraft:axolotl/variant": "blue"
                 }
               }
             },
@@ -436,9 +435,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:axolotl",
-                  "variant": "cyan"
+                "components": {
+                  "minecraft:axolotl/variant": "cyan"
                 }
               }
             },
@@ -660,9 +658,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:axolotl",
-                  "variant": "gold"
+                "components": {
+                  "minecraft:axolotl/variant": "gold"
                 }
               }
             },
@@ -884,9 +881,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:axolotl",
-                  "variant": "wild"
+                "components": {
+                  "minecraft:axolotl/variant": "wild"
                 }
               }
             },
@@ -1108,9 +1104,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:axolotl",
-                  "variant": "lucy"
+                "components": {
+                  "minecraft:axolotl/variant": "lucy"
                 }
               }
             },

--- a/data/minecraft/loot_table/entities/cat.json
+++ b/data/minecraft/loot_table/entities/cat.json
@@ -233,9 +233,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:cat",
-                  "variant": "minecraft:all_black"
+                "components": {
+                  "minecraft:cat/variant": "minecraft:all_black"
                 }
               }
             },
@@ -457,9 +456,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:cat",
-                  "variant": "minecraft:british_shorthair"
+                "components": {
+                  "minecraft:cat/variant": "minecraft:british_shorthair"
                 }
               }
             },
@@ -673,9 +671,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:cat",
-                  "variant": "minecraft:black"
+                "components": {
+                  "minecraft:cat/variant": "minecraft:black"
                 }
               }
             },
@@ -905,9 +902,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:cat",
-                  "variant": "minecraft:white"
+                "components": {
+                  "minecraft:cat/variant": "minecraft:white"
                 }
               }
             },
@@ -1129,9 +1125,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:cat",
-                  "variant": "minecraft:calico"
+                "components": {
+                  "minecraft:cat/variant": "minecraft:calico"
                 }
               }
             },
@@ -1353,9 +1348,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:cat",
-                  "variant": "minecraft:jellie"
+                "components": {
+                  "minecraft:cat/variant": "minecraft:jellie"
                 }
               }
             },
@@ -1577,9 +1571,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:cat",
-                  "variant": "minecraft:persian"
+                "components": {
+                  "minecraft:cat/variant": "minecraft:persian"
                 }
               }
             },
@@ -1801,9 +1794,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:cat",
-                  "variant": "minecraft:ragdoll"
+                "components": {
+                  "minecraft:cat/variant": "minecraft:ragdoll"
                 }
               }
             },
@@ -2025,9 +2017,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:cat",
-                  "variant": "minecraft:red"
+                "components": {
+                  "minecraft:cat/variant": "minecraft:red"
                 }
               }
             },
@@ -2249,9 +2240,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:cat",
-                  "variant": "minecraft:siamese"
+                "components": {
+                  "minecraft:cat/variant": "minecraft:siamese"
                 }
               }
             },
@@ -2473,9 +2463,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:cat",
-                  "variant": "minecraft:tabby"
+                "components": {
+                  "minecraft:cat/variant": "minecraft:tabby"
                 }
               }
             },

--- a/data/minecraft/loot_table/entities/fox.json
+++ b/data/minecraft/loot_table/entities/fox.json
@@ -212,9 +212,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:fox",
-                  "variant": "red"
+                "components": {
+                  "minecraft:fox/variant": "red"
                 }
               }
             },
@@ -436,9 +435,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:fox",
-                  "variant": "snow"
+                "components": {
+                  "minecraft:fox/variant": "snow"
                 }
               }
             },

--- a/data/minecraft/loot_table/entities/frog.json
+++ b/data/minecraft/loot_table/entities/frog.json
@@ -212,9 +212,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:frog",
-                  "variant": "minecraft:cold"
+                "components": {
+                  "minecraft:frog/variant": "minecraft:cold"
                 }
               }
             },
@@ -436,9 +435,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:frog",
-                  "variant": "minecraft:temperate"
+                "components": {
+                  "minecraft:frog/variant": "minecraft:temperate"
                 }
               }
             },
@@ -660,9 +658,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:frog",
-                  "variant": "minecraft:warm"
+                "components": {
+                  "minecraft:frog/variant": "minecraft:warm"
                 }
               }
             },

--- a/data/minecraft/loot_table/entities/horse.json
+++ b/data/minecraft/loot_table/entities/horse.json
@@ -242,9 +242,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:horse",
-                  "variant": "white"
+                "components": {
+                  "minecraft:horse/variant": "white"
                 }
               }
             },
@@ -466,9 +465,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:horse",
-                  "variant": "gray"
+                "components": {
+                  "minecraft:horse/variant": "gray"
                 }
               }
             },
@@ -690,9 +688,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:horse",
-                  "variant": "black"
+                "components": {
+                  "minecraft:horse/variant": "black"
                 }
               }
             },
@@ -914,9 +911,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:horse",
-                  "variant": "creamy"
+                "components": {
+                  "minecraft:horse/variant": "creamy"
                 }
               }
             },
@@ -1138,9 +1134,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:horse",
-                  "variant": "dark_brown"
+                "components": {
+                  "minecraft:horse/variant": "dark_brown"
                 }
               }
             },
@@ -1362,9 +1357,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:horse",
-                  "variant": "chestnut"
+                "components": {
+                  "minecraft:horse/variant": "chestnut"
                 }
               }
             },
@@ -1586,9 +1580,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:horse",
-                  "variant": "brown"
+                "components": {
+                  "minecraft:horse/variant": "brown"
                 }
               }
             },
@@ -1810,9 +1803,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:horse",
-                  "variant": "white"
+                "components": {
+                  "minecraft:horse/variant": "white"
                 }
               }
             },

--- a/data/minecraft/loot_table/entities/llama.json
+++ b/data/minecraft/loot_table/entities/llama.json
@@ -242,9 +242,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:llama",
-                  "variant": "brown"
+                "components": {
+                  "minecraft:llama/variant": "brown"
                 }
               }
             },
@@ -466,9 +465,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:llama",
-                  "variant": "gray"
+                "components": {
+                  "minecraft:llama/variant": "gray"
                 }
               }
             },
@@ -690,9 +688,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:llama",
-                  "variant": "creamy"
+                "components": {
+                  "minecraft:llama/variant": "creamy"
                 }
               }
             },
@@ -914,9 +911,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:llama",
-                  "variant": "white"
+                "components": {
+                  "minecraft:llama/variant": "white"
                 }
               }
             },

--- a/data/minecraft/loot_table/entities/magma_cube.json
+++ b/data/minecraft/loot_table/entities/magma_cube.json
@@ -69,9 +69,8 @@
               "predicate": {
                 "source_entity": {
                   "type": "minecraft:frog",
-                  "type_specific": {
-                    "type": "minecraft:frog",
-                    "variant": "minecraft:warm"
+                  "components": {
+                    "minecraft:frog/variant": "minecraft:warm"
                   }
                 }
               }
@@ -98,9 +97,8 @@
               "predicate": {
                 "source_entity": {
                   "type": "minecraft:frog",
-                  "type_specific": {
-                    "type": "minecraft:frog",
-                    "variant": "minecraft:cold"
+                  "components": {
+                    "minecraft:frog/variant": "minecraft:cold"
                   }
                 }
               }
@@ -127,9 +125,8 @@
               "predicate": {
                 "source_entity": {
                   "type": "minecraft:frog",
-                  "type_specific": {
-                    "type": "minecraft:frog",
-                    "variant": "minecraft:temperate"
+                  "components": {
+                    "minecraft:frog/variant": "minecraft:temperate"
                   }
                 }
               }

--- a/data/minecraft/loot_table/entities/mooshroom.json
+++ b/data/minecraft/loot_table/entities/mooshroom.json
@@ -312,9 +312,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:mooshroom",
-                  "variant": "red"
+                "components": {
+                  "minecraft:mooshroom/variant": "red"
                 }
               }
             },
@@ -536,9 +535,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:mooshroom",
-                  "variant": "brown"
+                "components": {
+                  "minecraft:mooshroom/variant": "brown"
                 }
               }
             },

--- a/data/minecraft/loot_table/entities/parrot.json
+++ b/data/minecraft/loot_table/entities/parrot.json
@@ -242,9 +242,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:parrot",
-                  "variant": "green"
+                "components": {
+                  "minecraft:parrot/variant": "green"
                 }
               }
             },
@@ -466,9 +465,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:parrot",
-                  "variant": "blue"
+                "components": {
+                  "minecraft:parrot/variant": "blue"
                 }
               }
             },
@@ -690,9 +688,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:parrot",
-                  "variant": "gray"
+                "components": {
+                  "minecraft:parrot/variant": "gray"
                 }
               }
             },
@@ -914,9 +911,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:parrot",
-                  "variant": "red_blue"
+                "components": {
+                  "minecraft:parrot/variant": "red_blue"
                 }
               }
             },
@@ -1138,9 +1134,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:parrot",
-                  "variant": "yellow_blue"
+                "components": {
+                  "minecraft:parrot/variant": "yellow_blue"
                 }
               }
             },

--- a/data/minecraft/loot_table/entities/rabbit.json
+++ b/data/minecraft/loot_table/entities/rabbit.json
@@ -337,9 +337,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:rabbit",
-                  "variant": "evil"
+                "components": {
+                  "minecraft:rabbit/variant": "evil"
                 }
               }
             },
@@ -561,9 +560,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:rabbit",
-                  "variant": "white"
+                "components": {
+                  "minecraft:rabbit/variant": "white"
                 }
               }
             },
@@ -785,9 +783,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:rabbit",
-                  "variant": "black"
+                "components": {
+                  "minecraft:rabbit/variant": "black"
                 }
               }
             },
@@ -1009,9 +1006,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:rabbit",
-                  "variant": "brown"
+                "components": {
+                  "minecraft:rabbit/variant": "brown"
                 }
               }
             },
@@ -1233,9 +1229,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:rabbit",
-                  "variant": "salt"
+                "components": {
+                  "minecraft:rabbit/variant": "salt"
                 }
               }
             },
@@ -1457,9 +1452,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:rabbit",
-                  "variant": "white_splotched"
+                "components": {
+                  "minecraft:rabbit/variant": "white_splotched"
                 }
               }
             },
@@ -1681,9 +1675,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:rabbit",
-                  "variant": "gold"
+                "components": {
+                  "minecraft:rabbit/variant": "gold"
                 }
               }
             },

--- a/data/minecraft/loot_table/entities/wolf.json
+++ b/data/minecraft/loot_table/entities/wolf.json
@@ -204,9 +204,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:wolf",
-                  "variant": "minecraft:woods"
+                "components": {
+                  "minecraft:wolf/variant": "minecraft:woods"
                 }
               }
             },
@@ -428,9 +427,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:wolf",
-                  "variant": "minecraft:spotted"
+                "components": {
+                  "minecraft:wolf/variant": "minecraft:spotted"
                 }
               }
             },
@@ -660,9 +658,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:wolf",
-                  "variant": "minecraft:striped"
+                "components": {
+                  "minecraft:wolf/variant": "minecraft:striped"
                 }
               }
             },
@@ -884,9 +881,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:wolf",
-                  "variant": "minecraft:rusty"
+                "components": {
+                  "minecraft:wolf/variant": "minecraft:rusty"
                 }
               }
             },
@@ -1108,9 +1104,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:wolf",
-                  "variant": "minecraft:pale"
+                "components": {
+                  "minecraft:wolf/variant": "minecraft:pale"
                 }
               }
             },
@@ -1332,9 +1327,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:wolf",
-                  "variant": "minecraft:chestnut"
+                "components": {
+                  "minecraft:wolf/variant": "minecraft:chestnut"
                 }
               }
             },
@@ -1556,9 +1550,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:wolf",
-                  "variant": "minecraft:black"
+                "components": {
+                  "minecraft:wolf/variant": "minecraft:black"
                 }
               }
             },
@@ -1780,9 +1773,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:wolf",
-                  "variant": "minecraft:ashen"
+                "components": {
+                  "minecraft:wolf/variant": "minecraft:ashen"
                 }
               }
             },
@@ -2004,9 +1996,8 @@
               "condition": "minecraft:entity_properties",
               "entity": "this",
               "predicate": {
-                "type_specific": {
-                  "type": "minecraft:wolf",
-                  "variant": "minecraft:snowy"
+                "components": {
+                  "minecraft:wolf/variant": "minecraft:snowy"
                 }
               }
             },


### PR DESCRIPTION
Since 1.21.5 type specific entity predicates are no longer used for their variant. They are now components and have to be tested through that section.