### PR TITLE
Fix wrong mob head conditions 

### DIFF
--- a/data/minecraft/loot_table/entities/allay.json
+++ b/data/minecraft/loot_table/entities/allay.json
@@ -52,10 +52,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -77,10 +73,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -104,10 +96,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -129,10 +117,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -156,10 +140,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -181,10 +161,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/armadillo.json
+++ b/data/minecraft/loot_table/entities/armadillo.json
@@ -46,10 +46,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -71,10 +67,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -98,10 +90,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -123,10 +111,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -150,10 +134,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -175,10 +155,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/axolotl.json
+++ b/data/minecraft/loot_table/entities/axolotl.json
@@ -46,10 +46,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -71,10 +67,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -98,10 +90,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -123,10 +111,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -150,10 +134,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -175,10 +155,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -270,10 +246,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -295,10 +267,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -322,10 +290,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -347,10 +311,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -374,10 +334,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -399,10 +355,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -494,10 +446,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -519,10 +467,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -546,10 +490,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -571,10 +511,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -598,10 +534,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -623,10 +555,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -718,10 +646,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -743,10 +667,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -770,10 +690,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -795,10 +711,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -822,10 +734,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -847,10 +755,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -942,10 +846,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -967,10 +867,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -994,10 +890,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1019,10 +911,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1046,10 +934,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1071,10 +955,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/bat.json
+++ b/data/minecraft/loot_table/entities/bat.json
@@ -46,10 +46,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -71,10 +67,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -98,10 +90,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -123,10 +111,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -150,10 +134,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -175,10 +155,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/bee.json
+++ b/data/minecraft/loot_table/entities/bee.json
@@ -46,10 +46,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -71,10 +67,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -98,10 +90,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -123,10 +111,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -150,10 +134,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -175,10 +155,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/blaze.json
+++ b/data/minecraft/loot_table/entities/blaze.json
@@ -5,10 +5,6 @@
       "bonus_rolls": 0.0,
       "conditions": [
         {
-          "condition": "reference",
-          "name": "mobheads:should_head_drop"
-        },
-        {
           "condition": "minecraft:killed_by_player"
         }
       ],

--- a/data/minecraft/loot_table/entities/blaze.json
+++ b/data/minecraft/loot_table/entities/blaze.json
@@ -81,10 +81,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -106,10 +102,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -133,10 +125,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -158,10 +146,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -185,10 +169,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -210,10 +190,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/bogged.json
+++ b/data/minecraft/loot_table/entities/bogged.json
@@ -146,10 +146,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -171,10 +167,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -198,10 +190,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -223,10 +211,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -250,10 +234,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -275,10 +255,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/bogged.json
+++ b/data/minecraft/loot_table/entities/bogged.json
@@ -65,10 +65,6 @@
       "bonus_rolls": 0.0,
       "conditions": [
         {
-          "condition": "reference",
-          "name": "mobheads:should_head_drop"
-        },
-        {
           "condition": "minecraft:killed_by_player"
         }
       ],

--- a/data/minecraft/loot_table/entities/breeze.json
+++ b/data/minecraft/loot_table/entities/breeze.json
@@ -5,10 +5,6 @@
       "bonus_rolls": 0.0,
       "conditions": [
         {
-          "condition": "reference",
-          "name": "mobheads:should_head_drop"
-        },
-        {
           "condition": "minecraft:killed_by_player"
         }
       ],

--- a/data/minecraft/loot_table/entities/breeze.json
+++ b/data/minecraft/loot_table/entities/breeze.json
@@ -81,10 +81,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -106,10 +102,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -133,10 +125,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -158,10 +146,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -185,10 +169,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -210,10 +190,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/camel.json
+++ b/data/minecraft/loot_table/entities/camel.json
@@ -46,10 +46,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -71,10 +67,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -98,10 +90,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -123,10 +111,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -150,10 +134,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -175,10 +155,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/cat.json
+++ b/data/minecraft/loot_table/entities/cat.json
@@ -67,10 +67,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -92,10 +88,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -119,10 +111,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -144,10 +132,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -171,10 +155,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -196,10 +176,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -291,10 +267,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -316,10 +288,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -343,10 +311,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -368,10 +332,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -395,10 +355,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -420,10 +376,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -515,10 +467,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -540,10 +488,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -567,10 +511,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -592,10 +532,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -619,10 +555,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -644,10 +576,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -739,10 +667,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -764,10 +688,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -791,10 +711,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -816,10 +732,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -843,10 +755,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -868,10 +776,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -963,10 +867,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -988,10 +888,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1015,10 +911,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1040,10 +932,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1067,10 +955,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1092,10 +976,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1187,10 +1067,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1212,10 +1088,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1239,10 +1111,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1264,10 +1132,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1291,10 +1155,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1316,10 +1176,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1411,10 +1267,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1436,10 +1288,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1463,10 +1311,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1488,10 +1332,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1515,10 +1355,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1540,10 +1376,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1635,10 +1467,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1660,10 +1488,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1687,10 +1511,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1712,10 +1532,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1739,10 +1555,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1764,10 +1576,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1859,10 +1667,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1884,10 +1688,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1911,10 +1711,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1936,10 +1732,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1963,10 +1755,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1988,10 +1776,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2083,10 +1867,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2108,10 +1888,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2135,10 +1911,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2160,10 +1932,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2187,10 +1955,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2212,10 +1976,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2307,10 +2067,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2332,10 +2088,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2359,10 +2111,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2384,10 +2132,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2411,10 +2155,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2436,10 +2176,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/cave_spider.json
+++ b/data/minecraft/loot_table/entities/cave_spider.json
@@ -35,10 +35,6 @@
       "bonus_rolls": 0.0,
       "conditions": [
         {
-          "condition": "reference",
-          "name": "mobheads:should_head_drop"
-        },
-        {
           "condition": "minecraft:killed_by_player"
         }
       ],

--- a/data/minecraft/loot_table/entities/cave_spider.json
+++ b/data/minecraft/loot_table/entities/cave_spider.json
@@ -111,10 +111,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -136,10 +132,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -163,10 +155,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -188,10 +176,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -215,10 +199,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -240,10 +220,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/chicken.json
+++ b/data/minecraft/loot_table/entities/chicken.json
@@ -133,10 +133,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -158,10 +154,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -185,10 +177,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -210,10 +198,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -237,10 +221,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -262,10 +242,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/chicken.json
+++ b/data/minecraft/loot_table/entities/chicken.json
@@ -40,10 +40,6 @@
             {
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:any_of",
                   "terms": [
                     {

--- a/data/minecraft/loot_table/entities/cod.json
+++ b/data/minecraft/loot_table/entities/cod.json
@@ -10,10 +10,6 @@
             {
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:any_of",
                   "terms": [
                     {
@@ -56,10 +52,6 @@
     {
       "bonus_rolls": 0.0,
       "conditions": [
-        {
-          "condition": "reference",
-          "name": "mobheads:should_head_drop"
-        },
         {
           "chance": 0.05,
           "condition": "minecraft:random_chance"

--- a/data/minecraft/loot_table/entities/cod.json
+++ b/data/minecraft/loot_table/entities/cod.json
@@ -110,10 +110,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -135,10 +131,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -162,10 +154,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -187,10 +175,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -214,10 +198,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -239,10 +219,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/cow.json
+++ b/data/minecraft/loot_table/entities/cow.json
@@ -142,10 +142,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -167,10 +163,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -194,10 +186,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -219,10 +207,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -246,10 +230,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -271,10 +251,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/cow.json
+++ b/data/minecraft/loot_table/entities/cow.json
@@ -49,10 +49,6 @@
             {
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:any_of",
                   "terms": [
                     {

--- a/data/minecraft/loot_table/entities/creaking.json
+++ b/data/minecraft/loot_table/entities/creaking.json
@@ -46,10 +46,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -71,10 +67,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -98,10 +90,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -123,10 +111,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -150,10 +134,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -175,10 +155,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/creeper.json
+++ b/data/minecraft/loot_table/entities/creeper.json
@@ -35,10 +35,6 @@
       "bonus_rolls": 0,
       "conditions": [
         {
-          "condition": "reference",
-          "name": "mobheads:should_head_drop"
-        },
-        {
           "condition": "minecraft:entity_properties",
           "entity": "attacker",
           "predicate": {

--- a/data/minecraft/loot_table/entities/creeper.json
+++ b/data/minecraft/loot_table/entities/creeper.json
@@ -72,10 +72,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -97,10 +93,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -124,10 +116,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -149,10 +137,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -176,10 +160,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -201,10 +181,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -287,10 +263,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -312,10 +284,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -339,10 +307,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -364,10 +328,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -391,10 +351,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -416,10 +372,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/dolphin.json
+++ b/data/minecraft/loot_table/entities/dolphin.json
@@ -112,10 +112,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -137,10 +133,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -164,10 +156,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -189,10 +177,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -216,10 +200,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -241,10 +221,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/dolphin.json
+++ b/data/minecraft/loot_table/entities/dolphin.json
@@ -28,10 +28,6 @@
             {
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:any_of",
                   "terms": [
                     {

--- a/data/minecraft/loot_table/entities/donkey.json
+++ b/data/minecraft/loot_table/entities/donkey.json
@@ -76,10 +76,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -101,10 +97,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -128,10 +120,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -153,10 +141,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -180,10 +164,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -205,10 +185,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/drowned.json
+++ b/data/minecraft/loot_table/entities/drowned.json
@@ -101,10 +101,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -126,10 +122,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -153,10 +145,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -178,10 +166,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -205,10 +189,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -230,10 +210,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/drowned.json
+++ b/data/minecraft/loot_table/entities/drowned.json
@@ -35,10 +35,6 @@
       "bonus_rolls": 0.0,
       "conditions": [
         {
-          "condition": "reference",
-          "name": "mobheads:should_head_drop"
-        },
-        {
           "condition": "minecraft:killed_by_player"
         },
         {

--- a/data/minecraft/loot_table/entities/elder_guardian.json
+++ b/data/minecraft/loot_table/entities/elder_guardian.json
@@ -245,10 +245,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -270,10 +266,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -297,10 +289,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -322,10 +310,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -349,10 +333,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -374,10 +354,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/elder_guardian.json
+++ b/data/minecraft/loot_table/entities/elder_guardian.json
@@ -49,10 +49,6 @@
             {
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:any_of",
                   "terms": [
                     {
@@ -116,10 +112,6 @@
       "bonus_rolls": 0.0,
       "conditions": [
         {
-          "condition": "reference",
-          "name": "mobheads:should_head_drop"
-        },
-        {
           "condition": "minecraft:killed_by_player"
         }
       ],
@@ -134,10 +126,6 @@
     {
       "bonus_rolls": 0.0,
       "conditions": [
-        {
-          "condition": "reference",
-          "name": "mobheads:should_head_drop"
-        },
         {
           "condition": "minecraft:killed_by_player"
         },
@@ -158,10 +146,6 @@
           "functions": [
             {
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:any_of",
                   "terms": [

--- a/data/minecraft/loot_table/entities/ender_dragon.json
+++ b/data/minecraft/loot_table/entities/ender_dragon.json
@@ -72,10 +72,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -97,10 +93,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -124,10 +116,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -149,10 +137,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -176,10 +160,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -201,10 +181,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/ender_dragon.json
+++ b/data/minecraft/loot_table/entities/ender_dragon.json
@@ -9,10 +9,6 @@
           "name": "minecraft:dragon_head",
           "conditions": [
             {
-              "condition": "reference",
-              "name": "mobheads:should_head_drop"
-            },
-            {
               "condition": "minecraft:random_chance",
               "chance": 0.95
             },

--- a/data/minecraft/loot_table/entities/enderman.json
+++ b/data/minecraft/loot_table/entities/enderman.json
@@ -76,10 +76,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -101,10 +97,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -128,10 +120,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -153,10 +141,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -180,10 +164,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -205,10 +185,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/endermite.json
+++ b/data/minecraft/loot_table/entities/endermite.json
@@ -46,10 +46,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -71,10 +67,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -98,10 +90,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -123,10 +111,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -150,10 +134,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -175,10 +155,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/evoker.json
+++ b/data/minecraft/loot_table/entities/evoker.json
@@ -15,10 +15,6 @@
       "bonus_rolls": 0.0,
       "conditions": [
         {
-          "condition": "reference",
-          "name": "mobheads:should_head_drop"
-        },
-        {
           "condition": "minecraft:killed_by_player"
         }
       ],

--- a/data/minecraft/loot_table/entities/evoker.json
+++ b/data/minecraft/loot_table/entities/evoker.json
@@ -91,10 +91,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -116,10 +112,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -143,10 +135,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -168,10 +156,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -195,10 +179,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -220,10 +200,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/fox.json
+++ b/data/minecraft/loot_table/entities/fox.json
@@ -46,10 +46,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -71,10 +67,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -98,10 +90,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -123,10 +111,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -150,10 +134,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -175,10 +155,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -270,10 +246,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -295,10 +267,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -322,10 +290,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -347,10 +311,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -374,10 +334,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -399,10 +355,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/frog.json
+++ b/data/minecraft/loot_table/entities/frog.json
@@ -46,10 +46,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -71,10 +67,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -98,10 +90,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -123,10 +111,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -150,10 +134,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -175,10 +155,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -270,10 +246,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -295,10 +267,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -322,10 +290,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -347,10 +311,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -374,10 +334,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -399,10 +355,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -494,10 +446,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -519,10 +467,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -546,10 +490,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -571,10 +511,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -598,10 +534,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -623,10 +555,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/ghast.json
+++ b/data/minecraft/loot_table/entities/ghast.json
@@ -106,10 +106,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -131,10 +127,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -158,10 +150,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -183,10 +171,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -210,10 +194,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -235,10 +215,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/glow_squid.json
+++ b/data/minecraft/loot_table/entities/glow_squid.json
@@ -76,10 +76,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -101,10 +97,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -128,10 +120,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -153,10 +141,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -180,10 +164,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -205,10 +185,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/goat.json
+++ b/data/minecraft/loot_table/entities/goat.json
@@ -46,10 +46,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -71,10 +67,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -98,10 +90,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -123,10 +111,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -150,10 +134,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -175,10 +155,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/guardian.json
+++ b/data/minecraft/loot_table/entities/guardian.json
@@ -49,10 +49,6 @@
             {
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:any_of",
                   "terms": [
                     {
@@ -116,10 +112,6 @@
       "bonus_rolls": 0.0,
       "conditions": [
         {
-          "condition": "reference",
-          "name": "mobheads:should_head_drop"
-        },
-        {
           "condition": "minecraft:killed_by_player"
         },
         {
@@ -139,10 +131,6 @@
           "functions": [
             {
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:any_of",
                   "terms": [

--- a/data/minecraft/loot_table/entities/guardian.json
+++ b/data/minecraft/loot_table/entities/guardian.json
@@ -216,10 +216,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -241,10 +237,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -268,10 +260,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -293,10 +281,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -320,10 +304,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -345,10 +325,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/hoglin.json
+++ b/data/minecraft/loot_table/entities/hoglin.json
@@ -142,10 +142,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -167,10 +163,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -194,10 +186,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -219,10 +207,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -246,10 +230,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -271,10 +251,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/hoglin.json
+++ b/data/minecraft/loot_table/entities/hoglin.json
@@ -19,10 +19,6 @@
             {
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:any_of",
                   "terms": [
                     {

--- a/data/minecraft/loot_table/entities/horse.json
+++ b/data/minecraft/loot_table/entities/horse.json
@@ -76,10 +76,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -101,10 +97,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -128,10 +120,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -153,10 +141,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -180,10 +164,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -205,10 +185,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -300,10 +276,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -325,10 +297,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -352,10 +320,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -377,10 +341,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -404,10 +364,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -429,10 +385,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -524,10 +476,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -549,10 +497,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -576,10 +520,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -601,10 +541,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -628,10 +564,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -653,10 +585,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -748,10 +676,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -773,10 +697,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -800,10 +720,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -825,10 +741,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -852,10 +764,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -877,10 +785,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -972,10 +876,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -997,10 +897,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1024,10 +920,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1049,10 +941,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1076,10 +964,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1101,10 +985,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1196,10 +1076,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1221,10 +1097,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1248,10 +1120,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1273,10 +1141,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1300,10 +1164,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1325,10 +1185,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1420,10 +1276,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1445,10 +1297,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1472,10 +1320,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1497,10 +1341,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1524,10 +1364,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1549,10 +1385,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1644,10 +1476,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1669,10 +1497,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1696,10 +1520,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1721,10 +1541,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1748,10 +1564,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1773,10 +1585,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/husk.json
+++ b/data/minecraft/loot_table/entities/husk.json
@@ -35,10 +35,6 @@
       "bonus_rolls": 0.0,
       "conditions": [
         {
-          "condition": "reference",
-          "name": "mobheads:should_head_drop"
-        },
-        {
           "condition": "minecraft:killed_by_player"
         },
         {
@@ -66,10 +62,6 @@
           "functions": [
             {
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:any_of",
                   "terms": [

--- a/data/minecraft/loot_table/entities/husk.json
+++ b/data/minecraft/loot_table/entities/husk.json
@@ -147,10 +147,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -172,10 +168,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -199,10 +191,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -224,10 +212,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -251,10 +235,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -276,10 +256,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/illusioner.json
+++ b/data/minecraft/loot_table/entities/illusioner.json
@@ -46,10 +46,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -71,10 +67,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -98,10 +90,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -123,10 +111,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -150,10 +134,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -175,10 +155,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/iron_golem.json
+++ b/data/minecraft/loot_table/entities/iron_golem.json
@@ -88,10 +88,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -113,10 +109,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -140,10 +132,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -165,10 +153,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -192,10 +176,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -217,10 +197,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/llama.json
+++ b/data/minecraft/loot_table/entities/llama.json
@@ -76,10 +76,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -101,10 +97,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -128,10 +120,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -153,10 +141,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -180,10 +164,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -205,10 +185,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -300,10 +276,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -325,10 +297,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -352,10 +320,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -377,10 +341,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -404,10 +364,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -429,10 +385,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -524,10 +476,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -549,10 +497,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -576,10 +520,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -601,10 +541,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -628,10 +564,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -653,10 +585,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -748,10 +676,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -773,10 +697,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -800,10 +720,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -825,10 +741,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -852,10 +764,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -877,10 +785,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/magma_cube.json
+++ b/data/minecraft/loot_table/entities/magma_cube.json
@@ -8,10 +8,6 @@
           "type": "minecraft:item",
           "conditions": [
             {
-              "condition": "reference",
-              "name": "mobheads:should_head_drop"
-            },
-            {
               "condition": "minecraft:inverted",
               "term": {
                 "condition": "minecraft:damage_source_properties",
@@ -61,10 +57,6 @@
           "type": "minecraft:item",
           "conditions": [
             {
-              "condition": "reference",
-              "name": "mobheads:should_head_drop"
-            },
-            {
               "condition": "minecraft:damage_source_properties",
               "predicate": {
                 "source_entity": {
@@ -90,10 +82,6 @@
           "type": "minecraft:item",
           "conditions": [
             {
-              "condition": "reference",
-              "name": "mobheads:should_head_drop"
-            },
-            {
               "condition": "minecraft:damage_source_properties",
               "predicate": {
                 "source_entity": {
@@ -118,10 +106,6 @@
         {
           "type": "minecraft:item",
           "conditions": [
-            {
-              "condition": "reference",
-              "name": "mobheads:should_head_drop"
-            },
             {
               "condition": "minecraft:damage_source_properties",
               "predicate": {
@@ -192,10 +176,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -217,10 +197,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -244,10 +220,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -269,10 +241,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -296,10 +264,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -321,10 +285,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/mooshroom.json
+++ b/data/minecraft/loot_table/entities/mooshroom.json
@@ -49,10 +49,6 @@
             {
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:any_of",
                   "terms": [
                     {

--- a/data/minecraft/loot_table/entities/mooshroom.json
+++ b/data/minecraft/loot_table/entities/mooshroom.json
@@ -142,10 +142,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -167,10 +163,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -194,10 +186,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -219,10 +207,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -246,10 +230,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -271,10 +251,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -366,10 +342,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -391,10 +363,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -418,10 +386,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -443,10 +407,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -470,10 +430,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -495,10 +451,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/mule.json
+++ b/data/minecraft/loot_table/entities/mule.json
@@ -76,10 +76,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -101,10 +97,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -128,10 +120,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -153,10 +141,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -180,10 +164,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -205,10 +185,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/ocelot.json
+++ b/data/minecraft/loot_table/entities/ocelot.json
@@ -46,10 +46,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -71,10 +67,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -98,10 +90,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -123,10 +111,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -150,10 +134,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -175,10 +155,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/panda.json
+++ b/data/minecraft/loot_table/entities/panda.json
@@ -63,10 +63,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -88,10 +84,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -115,10 +107,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -140,10 +128,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -167,10 +151,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -192,10 +172,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -284,10 +260,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -309,10 +281,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -336,10 +304,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -361,10 +325,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -388,10 +348,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -413,10 +369,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -505,10 +457,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -530,10 +478,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -557,10 +501,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -582,10 +522,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -609,10 +545,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -634,10 +566,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -726,10 +654,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -751,10 +675,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -778,10 +698,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -803,10 +719,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -830,10 +742,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -855,10 +763,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -947,10 +851,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -972,10 +872,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -999,10 +895,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1024,10 +916,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1051,10 +939,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1076,10 +960,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1168,10 +1048,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1193,10 +1069,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1220,10 +1092,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1245,10 +1113,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1272,10 +1136,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1297,10 +1157,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1389,10 +1245,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1414,10 +1266,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1441,10 +1289,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1466,10 +1310,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1493,10 +1333,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1518,10 +1354,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/parrot.json
+++ b/data/minecraft/loot_table/entities/parrot.json
@@ -76,10 +76,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -101,10 +97,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -128,10 +120,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -153,10 +141,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -180,10 +164,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -205,10 +185,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -300,10 +276,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -325,10 +297,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -352,10 +320,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -377,10 +341,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -404,10 +364,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -429,10 +385,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -524,10 +476,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -549,10 +497,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -576,10 +520,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -601,10 +541,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -628,10 +564,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -653,10 +585,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -748,10 +676,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -773,10 +697,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -800,10 +720,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -825,10 +741,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -852,10 +764,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -877,10 +785,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -972,10 +876,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -997,10 +897,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1024,10 +920,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1049,10 +941,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1076,10 +964,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1101,10 +985,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/phantom.json
+++ b/data/minecraft/loot_table/entities/phantom.json
@@ -5,10 +5,6 @@
       "bonus_rolls": 0.0,
       "conditions": [
         {
-          "condition": "reference",
-          "name": "mobheads:should_head_drop"
-        },
-        {
           "condition": "minecraft:killed_by_player"
         }
       ],

--- a/data/minecraft/loot_table/entities/phantom.json
+++ b/data/minecraft/loot_table/entities/phantom.json
@@ -81,10 +81,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -106,10 +102,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -133,10 +125,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -158,10 +146,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -185,10 +169,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -210,10 +190,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/pig.json
+++ b/data/minecraft/loot_table/entities/pig.json
@@ -19,10 +19,6 @@
             {
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:any_of",
                   "terms": [
                     {

--- a/data/minecraft/loot_table/entities/pig.json
+++ b/data/minecraft/loot_table/entities/pig.json
@@ -112,10 +112,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -137,10 +133,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -164,10 +156,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -189,10 +177,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -216,10 +200,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -241,10 +221,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/piglin.json
+++ b/data/minecraft/loot_table/entities/piglin.json
@@ -39,10 +39,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -64,10 +60,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -91,10 +83,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -116,10 +104,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -143,10 +127,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -168,10 +148,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/piglin_brute.json
+++ b/data/minecraft/loot_table/entities/piglin_brute.json
@@ -46,10 +46,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -71,10 +67,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -98,10 +90,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -123,10 +111,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -150,10 +134,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -175,10 +155,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/pillager.json
+++ b/data/minecraft/loot_table/entities/pillager.json
@@ -5,10 +5,6 @@
       "bonus_rolls": 0.0,
       "conditions": [
         {
-          "condition": "reference",
-          "name": "mobheads:should_head_drop"
-        },
-        {
           "condition": "minecraft:entity_properties",
           "entity": "this",
           "predicate": {
@@ -94,10 +90,6 @@
             }
           ],
           "conditions": [
-            {
-              "condition": "reference",
-              "name": "mobheads:should_head_drop"
-            },
             {
               "condition": "minecraft:random_chance",
               "chance": {

--- a/data/minecraft/loot_table/entities/polar_bear.json
+++ b/data/minecraft/loot_table/entities/polar_bear.json
@@ -173,10 +173,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -198,10 +194,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -225,10 +217,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -250,10 +238,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -277,10 +261,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -302,10 +282,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/polar_bear.json
+++ b/data/minecraft/loot_table/entities/polar_bear.json
@@ -10,10 +10,6 @@
             {
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:any_of",
                   "terms": [
                     {
@@ -74,10 +70,6 @@
           "functions": [
             {
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:any_of",
                   "terms": [

--- a/data/minecraft/loot_table/entities/pufferfish.json
+++ b/data/minecraft/loot_table/entities/pufferfish.json
@@ -79,10 +79,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -104,10 +100,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -131,10 +123,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -156,10 +144,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -183,10 +167,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -208,10 +188,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/pufferfish.json
+++ b/data/minecraft/loot_table/entities/pufferfish.json
@@ -22,10 +22,6 @@
       "bonus_rolls": 0.0,
       "conditions": [
         {
-          "condition": "reference",
-          "name": "mobheads:should_head_drop"
-        },
-        {
           "chance": 0.05,
           "condition": "minecraft:random_chance"
         }

--- a/data/minecraft/loot_table/entities/rabbit.json
+++ b/data/minecraft/loot_table/entities/rabbit.json
@@ -48,10 +48,6 @@
               "function": "minecraft:furnace_smelt",
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:any_of",
                   "terms": [
                     {
@@ -107,10 +103,6 @@
         }
       ],
       "conditions": [
-        {
-          "condition": "reference",
-          "name": "mobheads:should_head_drop"
-        },
         {
           "condition": "minecraft:killed_by_player"
         },

--- a/data/minecraft/loot_table/entities/rabbit.json
+++ b/data/minecraft/loot_table/entities/rabbit.json
@@ -163,10 +163,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -188,10 +184,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -215,10 +207,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -240,10 +228,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -267,10 +251,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -292,10 +272,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -387,10 +363,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -412,10 +384,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -439,10 +407,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -464,10 +428,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -491,10 +451,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -516,10 +472,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -611,10 +563,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -636,10 +584,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -663,10 +607,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -688,10 +628,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -715,10 +651,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -740,10 +672,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -835,10 +763,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -860,10 +784,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -887,10 +807,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -912,10 +828,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -939,10 +851,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -964,10 +872,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1059,10 +963,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1084,10 +984,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1111,10 +1007,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1136,10 +1028,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1163,10 +1051,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1188,10 +1072,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1283,10 +1163,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1308,10 +1184,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1335,10 +1207,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1360,10 +1228,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1387,10 +1251,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1412,10 +1272,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1507,10 +1363,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1532,10 +1384,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1559,10 +1407,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1584,10 +1428,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1611,10 +1451,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1636,10 +1472,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/ravager.json
+++ b/data/minecraft/loot_table/entities/ravager.json
@@ -63,10 +63,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -88,10 +84,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -115,10 +107,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -140,10 +128,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -167,10 +151,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -192,10 +172,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/salmon.json
+++ b/data/minecraft/loot_table/entities/salmon.json
@@ -10,10 +10,6 @@
             {
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:any_of",
                   "terms": [
                     {
@@ -56,10 +52,6 @@
     {
       "bonus_rolls": 0.0,
       "conditions": [
-        {
-          "condition": "reference",
-          "name": "mobheads:should_head_drop"
-        },
         {
           "chance": 0.05,
           "condition": "minecraft:random_chance"

--- a/data/minecraft/loot_table/entities/salmon.json
+++ b/data/minecraft/loot_table/entities/salmon.json
@@ -110,10 +110,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -135,10 +131,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -162,10 +154,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -187,10 +175,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -214,10 +198,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -239,10 +219,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/sheep/black.json
+++ b/data/minecraft/loot_table/entities/sheep/black.json
@@ -56,10 +56,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -81,10 +77,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -108,10 +100,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -133,10 +121,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -160,10 +144,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -185,10 +165,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/sheep/blue.json
+++ b/data/minecraft/loot_table/entities/sheep/blue.json
@@ -56,10 +56,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -81,10 +77,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -108,10 +100,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -133,10 +121,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -160,10 +144,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -185,10 +165,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/sheep/brown.json
+++ b/data/minecraft/loot_table/entities/sheep/brown.json
@@ -56,10 +56,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -81,10 +77,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -108,10 +100,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -133,10 +121,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -160,10 +144,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -185,10 +165,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/sheep/cyan.json
+++ b/data/minecraft/loot_table/entities/sheep/cyan.json
@@ -56,10 +56,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -81,10 +77,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -108,10 +100,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -133,10 +121,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -160,10 +144,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -185,10 +165,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/sheep/gray.json
+++ b/data/minecraft/loot_table/entities/sheep/gray.json
@@ -56,10 +56,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -81,10 +77,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -108,10 +100,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -133,10 +121,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -160,10 +144,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -185,10 +165,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/sheep/green.json
+++ b/data/minecraft/loot_table/entities/sheep/green.json
@@ -56,10 +56,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -81,10 +77,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -108,10 +100,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -133,10 +121,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -160,10 +144,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -185,10 +165,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/sheep/light_blue.json
+++ b/data/minecraft/loot_table/entities/sheep/light_blue.json
@@ -56,10 +56,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -81,10 +77,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -108,10 +100,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -133,10 +121,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -160,10 +144,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -185,10 +165,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/sheep/light_gray.json
+++ b/data/minecraft/loot_table/entities/sheep/light_gray.json
@@ -56,10 +56,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -81,10 +77,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -108,10 +100,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -133,10 +121,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -160,10 +144,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -185,10 +165,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/sheep/lime.json
+++ b/data/minecraft/loot_table/entities/sheep/lime.json
@@ -56,10 +56,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -81,10 +77,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -108,10 +100,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -133,10 +121,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -160,10 +144,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -185,10 +165,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/sheep/magenta.json
+++ b/data/minecraft/loot_table/entities/sheep/magenta.json
@@ -56,10 +56,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -81,10 +77,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -108,10 +100,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -133,10 +121,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -160,10 +144,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -185,10 +165,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/sheep/orange.json
+++ b/data/minecraft/loot_table/entities/sheep/orange.json
@@ -56,10 +56,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -81,10 +77,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -108,10 +100,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -133,10 +121,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -160,10 +144,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -185,10 +165,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/sheep/pink.json
+++ b/data/minecraft/loot_table/entities/sheep/pink.json
@@ -56,10 +56,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -81,10 +77,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -108,10 +100,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -133,10 +121,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -160,10 +144,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -185,10 +165,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/sheep/purple.json
+++ b/data/minecraft/loot_table/entities/sheep/purple.json
@@ -56,10 +56,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -81,10 +77,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -108,10 +100,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -133,10 +121,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -160,10 +144,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -185,10 +165,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/sheep/red.json
+++ b/data/minecraft/loot_table/entities/sheep/red.json
@@ -56,10 +56,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -81,10 +77,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -108,10 +100,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -133,10 +121,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -160,10 +144,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -185,10 +165,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/sheep/white.json
+++ b/data/minecraft/loot_table/entities/sheep/white.json
@@ -56,10 +56,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -81,10 +77,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -108,10 +100,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -133,10 +121,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -160,10 +144,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -185,10 +165,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/sheep/yellow.json
+++ b/data/minecraft/loot_table/entities/sheep/yellow.json
@@ -56,10 +56,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -81,10 +77,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -108,10 +100,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -133,10 +121,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -160,10 +144,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -185,10 +165,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/shulker.json
+++ b/data/minecraft/loot_table/entities/shulker.json
@@ -68,10 +68,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -93,10 +89,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -120,10 +112,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -145,10 +133,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -172,10 +156,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -197,10 +177,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/shulker.json
+++ b/data/minecraft/loot_table/entities/shulker.json
@@ -5,10 +5,6 @@
       "bonus_rolls": 0.0,
       "conditions": [
         {
-          "condition": "reference",
-          "name": "mobheads:should_head_drop"
-        },
-        {
           "condition": "minecraft:random_chance_with_enchanted_bonus",
           "enchanted_chance": {
             "type": "minecraft:linear",

--- a/data/minecraft/loot_table/entities/silverfish.json
+++ b/data/minecraft/loot_table/entities/silverfish.json
@@ -46,10 +46,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -71,10 +67,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -98,10 +90,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -123,10 +111,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -150,10 +134,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -175,10 +155,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/skeleton.json
+++ b/data/minecraft/loot_table/entities/skeleton.json
@@ -82,10 +82,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -114,10 +110,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -139,10 +131,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -166,10 +154,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -192,10 +176,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -217,10 +197,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/skeleton_horse.json
+++ b/data/minecraft/loot_table/entities/skeleton_horse.json
@@ -76,10 +76,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -101,10 +97,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -128,10 +120,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -153,10 +141,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -180,10 +164,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -205,10 +185,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/slime.json
+++ b/data/minecraft/loot_table/entities/slime.json
@@ -5,10 +5,6 @@
       "bonus_rolls": 0.0,
       "conditions": [
         {
-          "condition": "reference",
-          "name": "mobheads:should_head_drop"
-        },
-        {
           "condition": "minecraft:entity_properties",
           "entity": "this",
           "predicate": {
@@ -23,10 +19,6 @@
         {
           "type": "minecraft:item",
           "conditions": [
-            {
-              "condition": "reference",
-              "name": "mobheads:should_head_drop"
-            },
             {
               "condition": "minecraft:inverted",
               "term": {
@@ -64,10 +56,6 @@
         {
           "type": "minecraft:item",
           "conditions": [
-            {
-              "condition": "reference",
-              "name": "mobheads:should_head_drop"
-            },
             {
               "condition": "minecraft:damage_source_properties",
               "predicate": {

--- a/data/minecraft/loot_table/entities/slime.json
+++ b/data/minecraft/loot_table/entities/slime.json
@@ -122,10 +122,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -147,10 +143,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -174,10 +166,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -199,10 +187,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -226,10 +210,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -251,10 +231,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/sniffer.json
+++ b/data/minecraft/loot_table/entities/sniffer.json
@@ -46,10 +46,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -71,10 +67,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -98,10 +90,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -123,10 +111,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -150,10 +134,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -175,10 +155,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/snow_golem.json
+++ b/data/minecraft/loot_table/entities/snow_golem.json
@@ -67,10 +67,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -92,10 +88,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -119,10 +111,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -144,10 +132,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -171,10 +155,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -196,10 +176,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/spider.json
+++ b/data/minecraft/loot_table/entities/spider.json
@@ -35,10 +35,6 @@
       "bonus_rolls": 0.0,
       "conditions": [
         {
-          "condition": "reference",
-          "name": "mobheads:should_head_drop"
-        },
-        {
           "condition": "minecraft:killed_by_player"
         }
       ],

--- a/data/minecraft/loot_table/entities/spider.json
+++ b/data/minecraft/loot_table/entities/spider.json
@@ -111,10 +111,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -136,10 +132,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -163,10 +155,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -188,10 +176,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -215,10 +199,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -240,10 +220,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/squid.json
+++ b/data/minecraft/loot_table/entities/squid.json
@@ -76,10 +76,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -101,10 +97,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -128,10 +120,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -153,10 +141,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -180,10 +164,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -205,10 +185,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/stray.json
+++ b/data/minecraft/loot_table/entities/stray.json
@@ -146,10 +146,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -171,10 +167,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -198,10 +190,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -223,10 +211,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -250,10 +234,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -275,10 +255,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/stray.json
+++ b/data/minecraft/loot_table/entities/stray.json
@@ -65,10 +65,6 @@
       "bonus_rolls": 0.0,
       "conditions": [
         {
-          "condition": "reference",
-          "name": "mobheads:should_head_drop"
-        },
-        {
           "condition": "minecraft:killed_by_player"
         }
       ],

--- a/data/minecraft/loot_table/entities/strider.json
+++ b/data/minecraft/loot_table/entities/strider.json
@@ -76,10 +76,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -101,10 +97,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -128,10 +120,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -153,10 +141,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -180,10 +164,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -205,10 +185,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/tadpole.json
+++ b/data/minecraft/loot_table/entities/tadpole.json
@@ -46,10 +46,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -71,10 +67,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -98,10 +90,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -123,10 +111,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -150,10 +134,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -175,10 +155,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/trader_llama.json
+++ b/data/minecraft/loot_table/entities/trader_llama.json
@@ -76,10 +76,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -101,10 +97,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -128,10 +120,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -153,10 +141,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -180,10 +164,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -205,10 +185,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -297,10 +273,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -322,10 +294,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -349,10 +317,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -374,10 +338,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -401,10 +361,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -426,10 +382,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -518,10 +470,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -543,10 +491,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -570,10 +514,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -595,10 +535,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -622,10 +558,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -647,10 +579,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -739,10 +667,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -764,10 +688,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -791,10 +711,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -816,10 +732,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -843,10 +755,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -868,10 +776,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/tropical_fish.json
+++ b/data/minecraft/loot_table/entities/tropical_fish.json
@@ -79,10 +79,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -104,10 +100,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -131,10 +123,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -156,10 +144,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -183,10 +167,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -208,10 +188,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/tropical_fish.json
+++ b/data/minecraft/loot_table/entities/tropical_fish.json
@@ -22,10 +22,6 @@
       "bonus_rolls": 0.0,
       "conditions": [
         {
-          "condition": "reference",
-          "name": "mobheads:should_head_drop"
-        },
-        {
           "chance": 0.05,
           "condition": "minecraft:random_chance"
         }

--- a/data/minecraft/loot_table/entities/turtle.json
+++ b/data/minecraft/loot_table/entities/turtle.json
@@ -100,10 +100,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -125,10 +121,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -152,10 +144,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -177,10 +165,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -204,10 +188,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -229,10 +209,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/turtle.json
+++ b/data/minecraft/loot_table/entities/turtle.json
@@ -36,10 +36,6 @@
       "bonus_rolls": 0.0,
       "conditions": [
         {
-          "condition": "reference",
-          "name": "mobheads:should_head_drop"
-        },
-        {
           "condition": "minecraft:damage_source_properties",
           "predicate": {
             "tags": [

--- a/data/minecraft/loot_table/entities/vex.json
+++ b/data/minecraft/loot_table/entities/vex.json
@@ -46,10 +46,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -71,10 +67,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -98,10 +90,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -123,10 +111,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -150,10 +134,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -175,10 +155,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/villager.json
+++ b/data/minecraft/loot_table/entities/villager.json
@@ -45,10 +45,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -70,10 +66,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -97,10 +89,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -122,10 +110,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -149,10 +133,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -174,10 +154,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -260,10 +236,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -285,10 +257,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -312,10 +280,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -337,10 +301,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -364,10 +324,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -389,10 +345,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -475,10 +427,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -500,10 +448,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -527,10 +471,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -552,10 +492,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -579,10 +515,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -604,10 +536,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -690,10 +618,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -715,10 +639,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -742,10 +662,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -767,10 +683,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -794,10 +706,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -819,10 +727,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -905,10 +809,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -930,10 +830,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -957,10 +853,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -982,10 +874,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1009,10 +897,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1034,10 +918,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1120,10 +1000,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1145,10 +1021,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1172,10 +1044,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1197,10 +1065,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1224,10 +1088,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1249,10 +1109,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1335,10 +1191,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1360,10 +1212,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1387,10 +1235,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1412,10 +1256,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1439,10 +1279,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1464,10 +1300,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1550,10 +1382,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1575,10 +1403,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1602,10 +1426,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1627,10 +1447,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1654,10 +1470,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1679,10 +1491,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1765,10 +1573,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1790,10 +1594,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1817,10 +1617,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1842,10 +1638,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1869,10 +1661,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1894,10 +1682,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1980,10 +1764,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2005,10 +1785,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2032,10 +1808,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2057,10 +1829,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2084,10 +1852,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2109,10 +1873,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2195,10 +1955,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2220,10 +1976,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2247,10 +1999,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2272,10 +2020,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2299,10 +2043,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2324,10 +2064,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2410,10 +2146,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2435,10 +2167,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2462,10 +2190,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2487,10 +2211,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2514,10 +2234,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2539,10 +2255,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2625,10 +2337,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2650,10 +2358,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2677,10 +2381,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2702,10 +2402,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2729,10 +2425,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2754,10 +2446,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2840,10 +2528,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2865,10 +2549,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2892,10 +2572,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2917,10 +2593,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2944,10 +2616,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2969,10 +2637,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -3055,10 +2719,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -3080,10 +2740,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -3107,10 +2763,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -3132,10 +2784,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -3159,10 +2807,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -3184,10 +2828,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -3270,10 +2910,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -3295,10 +2931,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -3322,10 +2954,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -3347,10 +2975,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -3374,10 +2998,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -3399,10 +3019,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -3485,10 +3101,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -3510,10 +3122,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -3537,10 +3145,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -3562,10 +3166,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -3589,10 +3189,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -3614,10 +3210,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -3701,10 +3293,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -3726,10 +3314,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -3753,10 +3337,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -3778,10 +3358,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -3805,10 +3381,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -3830,10 +3402,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -3916,10 +3484,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -3941,10 +3505,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -3968,10 +3528,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -3993,10 +3549,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4020,10 +3572,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -4045,10 +3593,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4131,10 +3675,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -4156,10 +3696,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4183,10 +3719,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -4208,10 +3740,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4235,10 +3763,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -4260,10 +3784,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4346,10 +3866,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -4371,10 +3887,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4398,10 +3910,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -4423,10 +3931,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4450,10 +3954,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -4475,10 +3975,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4561,10 +4057,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -4586,10 +4078,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4613,10 +4101,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -4638,10 +4122,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4665,10 +4145,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -4690,10 +4166,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4776,10 +4248,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -4801,10 +4269,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4828,10 +4292,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -4853,10 +4313,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4880,10 +4336,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -4905,10 +4357,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4991,10 +4439,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5016,10 +4460,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -5043,10 +4483,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5068,10 +4504,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -5095,10 +4527,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5120,10 +4548,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -5206,10 +4630,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5231,10 +4651,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -5258,10 +4674,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5283,10 +4695,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -5310,10 +4718,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5335,10 +4739,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -5421,10 +4821,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5446,10 +4842,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -5473,10 +4865,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5498,10 +4886,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -5525,10 +4909,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5550,10 +4930,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -5636,10 +5012,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5661,10 +5033,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -5688,10 +5056,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5713,10 +5077,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -5740,10 +5100,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5765,10 +5121,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -5851,10 +5203,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5876,10 +5224,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -5903,10 +5247,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5928,10 +5268,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -5955,10 +5291,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5980,10 +5312,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -6062,10 +5390,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -6087,10 +5411,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -6114,10 +5434,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -6139,10 +5455,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -6166,10 +5478,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -6191,10 +5499,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -6277,10 +5581,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -6302,10 +5602,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -6329,10 +5625,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -6354,10 +5646,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -6381,10 +5669,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -6406,10 +5690,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -6492,10 +5772,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -6517,10 +5793,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -6544,10 +5816,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -6569,10 +5837,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -6596,10 +5860,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -6621,10 +5881,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -6707,10 +5963,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -6732,10 +5984,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -6759,10 +6007,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -6784,10 +6028,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -6811,10 +6051,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -6836,10 +6072,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -6923,10 +6155,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -6948,10 +6176,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -6975,10 +6199,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -7000,10 +6220,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7027,10 +6243,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -7052,10 +6264,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7138,10 +6346,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -7163,10 +6367,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7190,10 +6390,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -7215,10 +6411,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7242,10 +6434,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -7267,10 +6455,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7353,10 +6537,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -7378,10 +6558,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7405,10 +6581,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -7430,10 +6602,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7457,10 +6625,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -7482,10 +6646,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7568,10 +6728,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -7593,10 +6749,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7620,10 +6772,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -7645,10 +6793,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7672,10 +6816,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -7697,10 +6837,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7783,10 +6919,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -7808,10 +6940,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7835,10 +6963,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -7860,10 +6984,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7887,10 +7007,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -7912,10 +7028,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7998,10 +7110,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8023,10 +7131,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -8050,10 +7154,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8075,10 +7175,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -8102,10 +7198,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8127,10 +7219,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -8213,10 +7301,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8238,10 +7322,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -8265,10 +7345,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8290,10 +7366,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -8317,10 +7389,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8342,10 +7410,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -8428,10 +7492,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8453,10 +7513,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -8480,10 +7536,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8505,10 +7557,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -8532,10 +7580,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8557,10 +7601,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -8643,10 +7683,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8668,10 +7704,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -8695,10 +7727,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8720,10 +7748,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -8747,10 +7771,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8772,10 +7792,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -8858,10 +7874,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8883,10 +7895,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -8910,10 +7918,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8935,10 +7939,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -8962,10 +7962,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8987,10 +7983,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -9073,10 +8065,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -9098,10 +8086,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -9125,10 +8109,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -9150,10 +8130,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -9177,10 +8153,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -9202,10 +8174,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -9288,10 +8256,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -9313,10 +8277,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -9340,10 +8300,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -9365,10 +8321,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -9392,10 +8344,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -9417,10 +8365,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -9503,10 +8447,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -9528,10 +8468,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -9555,10 +8491,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -9580,10 +8512,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -9607,10 +8535,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -9632,10 +8556,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -9719,10 +8639,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -9744,10 +8660,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -9771,10 +8683,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -9796,10 +8704,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -9823,10 +8727,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -9848,10 +8748,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -9934,10 +8830,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -9959,10 +8851,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -9986,10 +8874,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -10011,10 +8895,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -10038,10 +8918,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -10063,10 +8939,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -10150,10 +9022,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -10175,10 +9043,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -10202,10 +9066,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -10227,10 +9087,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -10254,10 +9110,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -10279,10 +9131,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -10365,10 +9213,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -10390,10 +9234,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -10417,10 +9257,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -10442,10 +9278,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -10469,10 +9301,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -10494,10 +9322,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -10580,10 +9404,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -10605,10 +9425,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -10632,10 +9448,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -10657,10 +9469,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -10684,10 +9492,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -10709,10 +9513,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -10795,10 +9595,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -10820,10 +9616,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -10847,10 +9639,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -10872,10 +9660,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -10899,10 +9683,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -10924,10 +9704,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11010,10 +9786,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -11035,10 +9807,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11062,10 +9830,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -11087,10 +9851,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11114,10 +9874,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -11139,10 +9895,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11225,10 +9977,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -11250,10 +9998,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11277,10 +10021,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -11302,10 +10042,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11329,10 +10065,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -11354,10 +10086,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11440,10 +10168,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -11465,10 +10189,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11492,10 +10212,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -11517,10 +10233,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11544,10 +10256,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -11569,10 +10277,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11655,10 +10359,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -11680,10 +10380,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11707,10 +10403,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -11732,10 +10424,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11759,10 +10447,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -11784,10 +10468,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11870,10 +10550,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -11895,10 +10571,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11922,10 +10594,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -11947,10 +10615,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11974,10 +10638,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -11999,10 +10659,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -12085,10 +10741,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -12110,10 +10762,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -12137,10 +10785,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -12162,10 +10806,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -12189,10 +10829,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -12214,10 +10850,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -12300,10 +10932,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -12325,10 +10953,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -12352,10 +10976,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -12377,10 +10997,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -12404,10 +11020,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -12429,10 +11041,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -12515,10 +11123,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -12540,10 +11144,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -12567,10 +11167,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -12592,10 +11188,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -12619,10 +11211,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -12644,10 +11232,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -12730,10 +11314,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -12755,10 +11335,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -12782,10 +11358,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -12807,10 +11379,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -12834,10 +11402,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -12859,10 +11423,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -12945,10 +11505,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -12970,10 +11526,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -12997,10 +11549,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -13022,10 +11570,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -13049,10 +11593,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -13074,10 +11614,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -13160,10 +11696,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -13185,10 +11717,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -13212,10 +11740,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -13237,10 +11761,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -13264,10 +11784,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -13289,10 +11805,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -13376,10 +11888,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -13401,10 +11909,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -13428,10 +11932,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -13453,10 +11953,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -13480,10 +11976,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -13505,10 +11997,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -13591,10 +12079,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -13616,10 +12100,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -13643,10 +12123,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -13668,10 +12144,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -13695,10 +12167,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -13720,10 +12188,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -13806,10 +12270,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -13831,10 +12291,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -13858,10 +12314,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -13883,10 +12335,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -13910,10 +12358,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -13935,10 +12379,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14021,10 +12461,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -14046,10 +12482,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14073,10 +12505,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -14098,10 +12526,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14125,10 +12549,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -14150,10 +12570,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14236,10 +12652,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -14261,10 +12673,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14288,10 +12696,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -14313,10 +12717,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14340,10 +12740,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -14365,10 +12761,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14451,10 +12843,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -14476,10 +12864,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14503,10 +12887,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -14528,10 +12908,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14555,10 +12931,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -14580,10 +12952,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14666,10 +13034,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -14691,10 +13055,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14718,10 +13078,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -14743,10 +13099,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14770,10 +13122,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -14795,10 +13143,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14881,10 +13225,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -14906,10 +13246,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14933,10 +13269,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -14958,10 +13290,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14985,10 +13313,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15010,10 +13334,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -15096,10 +13416,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15121,10 +13437,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -15148,10 +13460,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15173,10 +13481,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -15200,10 +13504,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15225,10 +13525,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -15311,10 +13607,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15336,10 +13628,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -15363,10 +13651,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15388,10 +13672,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -15415,10 +13695,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15440,10 +13716,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -15526,10 +13798,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15551,10 +13819,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -15578,10 +13842,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15603,10 +13863,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -15630,10 +13886,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15655,10 +13907,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -15741,10 +13989,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15766,10 +14010,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -15793,10 +14033,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15818,10 +14054,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -15845,10 +14077,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15870,10 +14098,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -15956,10 +14180,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15981,10 +14201,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -16008,10 +14224,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -16033,10 +14245,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -16060,10 +14268,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -16085,10 +14289,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -16171,10 +14371,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -16196,10 +14392,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -16223,10 +14415,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -16248,10 +14436,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -16275,10 +14459,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -16300,10 +14480,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -16386,10 +14562,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -16411,10 +14583,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -16438,10 +14606,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -16463,10 +14627,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -16490,10 +14650,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -16515,10 +14671,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -16602,10 +14754,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -16627,10 +14775,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -16654,10 +14798,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -16679,10 +14819,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -16706,10 +14842,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -16731,10 +14863,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -16817,10 +14945,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -16842,10 +14966,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -16869,10 +14989,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -16894,10 +15010,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -16921,10 +15033,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -16946,10 +15054,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17032,10 +15136,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -17057,10 +15157,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17084,10 +15180,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -17109,10 +15201,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17136,10 +15224,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -17161,10 +15245,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17247,10 +15327,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -17272,10 +15348,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17299,10 +15371,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -17324,10 +15392,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17351,10 +15415,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -17376,10 +15436,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17462,10 +15518,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -17487,10 +15539,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17514,10 +15562,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -17539,10 +15583,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17566,10 +15606,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -17591,10 +15627,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17677,10 +15709,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -17702,10 +15730,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17729,10 +15753,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -17754,10 +15774,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17781,10 +15797,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -17806,10 +15818,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17892,10 +15900,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -17917,10 +15921,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17944,10 +15944,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -17969,10 +15965,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17996,10 +15988,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18021,10 +16009,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -18107,10 +16091,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18132,10 +16112,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -18159,10 +16135,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18184,10 +16156,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -18211,10 +16179,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18236,10 +16200,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -18322,10 +16282,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18347,10 +16303,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -18374,10 +16326,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18399,10 +16347,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -18426,10 +16370,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18451,10 +16391,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -18537,10 +16473,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18562,10 +16494,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -18589,10 +16517,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18614,10 +16538,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -18641,10 +16561,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18666,10 +16582,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -18752,10 +16664,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18777,10 +16685,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -18804,10 +16708,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18829,10 +16729,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -18856,10 +16752,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18881,10 +16773,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -18967,10 +16855,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18992,10 +16876,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -19019,10 +16899,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -19044,10 +16920,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -19071,10 +16943,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -19096,10 +16964,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -19182,10 +17046,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -19207,10 +17067,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -19234,10 +17090,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -19259,10 +17111,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -19286,10 +17134,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -19311,10 +17155,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -19397,10 +17237,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -19422,10 +17258,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -19449,10 +17281,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -19474,10 +17302,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -19501,10 +17325,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -19526,10 +17346,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -19612,10 +17428,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -19637,10 +17449,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -19664,10 +17472,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -19689,10 +17493,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -19716,10 +17516,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -19741,10 +17537,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -19828,10 +17620,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -19853,10 +17641,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -19880,10 +17664,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -19905,10 +17685,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -19932,10 +17708,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -19957,10 +17729,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -20043,10 +17811,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -20068,10 +17832,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -20095,10 +17855,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -20120,10 +17876,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -20147,10 +17899,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -20172,10 +17920,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -20258,10 +18002,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -20283,10 +18023,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -20310,10 +18046,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -20335,10 +18067,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -20362,10 +18090,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -20387,10 +18111,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -20473,10 +18193,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -20498,10 +18214,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -20525,10 +18237,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -20550,10 +18258,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -20577,10 +18281,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -20602,10 +18302,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -20688,10 +18384,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -20713,10 +18405,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -20740,10 +18428,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -20765,10 +18449,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -20792,10 +18472,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -20817,10 +18493,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -20903,10 +18575,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -20928,10 +18596,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -20955,10 +18619,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -20980,10 +18640,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21007,10 +18663,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -21032,10 +18684,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21118,10 +18766,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -21143,10 +18787,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21170,10 +18810,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -21195,10 +18831,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21222,10 +18854,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -21247,10 +18875,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21333,10 +18957,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -21358,10 +18978,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21385,10 +19001,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -21410,10 +19022,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21437,10 +19045,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -21462,10 +19066,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21548,10 +19148,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -21573,10 +19169,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21600,10 +19192,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -21625,10 +19213,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21652,10 +19236,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -21677,10 +19257,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21763,10 +19339,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -21788,10 +19360,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21815,10 +19383,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -21840,10 +19404,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21867,10 +19427,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -21892,10 +19448,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21978,10 +19530,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -22003,10 +19551,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -22030,10 +19574,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -22055,10 +19595,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -22082,10 +19618,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -22107,10 +19639,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -22193,10 +19721,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -22218,10 +19742,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -22245,10 +19765,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -22270,10 +19786,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -22297,10 +19809,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -22322,10 +19830,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -22408,10 +19912,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -22433,10 +19933,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -22460,10 +19956,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -22485,10 +19977,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -22512,10 +20000,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -22537,10 +20021,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/vindicator.json
+++ b/data/minecraft/loot_table/entities/vindicator.json
@@ -5,10 +5,6 @@
       "bonus_rolls": 0.0,
       "conditions": [
         {
-          "condition": "reference",
-          "name": "mobheads:should_head_drop"
-        },
-        {
           "condition": "minecraft:killed_by_player"
         }
       ],

--- a/data/minecraft/loot_table/entities/vindicator.json
+++ b/data/minecraft/loot_table/entities/vindicator.json
@@ -81,10 +81,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -106,10 +102,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -133,10 +125,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -158,10 +146,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -185,10 +169,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -210,10 +190,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/wandering_trader.json
+++ b/data/minecraft/loot_table/entities/wandering_trader.json
@@ -46,10 +46,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -71,10 +67,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -98,10 +90,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -123,10 +111,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -150,10 +134,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -175,10 +155,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/warden.json
+++ b/data/minecraft/loot_table/entities/warden.json
@@ -56,10 +56,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -81,10 +77,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -108,10 +100,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -133,10 +121,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -160,10 +144,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -185,10 +165,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/witch.json
+++ b/data/minecraft/loot_table/entities/witch.json
@@ -231,10 +231,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -256,10 +252,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -283,10 +275,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -308,10 +296,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -335,10 +319,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -360,10 +340,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/wither.json
+++ b/data/minecraft/loot_table/entities/wither.json
@@ -46,10 +46,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -71,10 +67,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -98,10 +90,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -123,10 +111,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -150,10 +134,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -175,10 +155,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -260,10 +236,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -285,10 +257,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -312,10 +280,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -337,10 +301,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -364,10 +324,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -389,10 +345,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/wolf.json
+++ b/data/minecraft/loot_table/entities/wolf.json
@@ -46,10 +46,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -71,10 +67,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -98,10 +90,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -123,10 +111,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -150,10 +134,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -175,10 +155,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -270,10 +246,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -295,10 +267,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -322,10 +290,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -347,10 +311,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -374,10 +334,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -399,10 +355,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -494,10 +446,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -519,10 +467,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -546,10 +490,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -571,10 +511,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -598,10 +534,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -623,10 +555,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -718,10 +646,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -743,10 +667,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -770,10 +690,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -795,10 +711,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -822,10 +734,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -847,10 +755,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -942,10 +846,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -967,10 +867,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -994,10 +890,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1019,10 +911,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1046,10 +934,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1071,10 +955,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1166,10 +1046,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1191,10 +1067,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1218,10 +1090,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1243,10 +1111,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1270,10 +1134,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1295,10 +1155,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1390,10 +1246,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1415,10 +1267,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1442,10 +1290,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1467,10 +1311,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1494,10 +1334,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1519,10 +1355,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1614,10 +1446,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1639,10 +1467,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1666,10 +1490,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1691,10 +1511,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1718,10 +1534,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1743,10 +1555,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1838,10 +1646,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1863,10 +1667,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1890,10 +1690,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1915,10 +1711,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1942,10 +1734,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1967,10 +1755,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/zoglin.json
+++ b/data/minecraft/loot_table/entities/zoglin.json
@@ -76,10 +76,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -101,10 +97,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -128,10 +120,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -153,10 +141,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -180,10 +164,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -205,10 +185,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/zombie.json
+++ b/data/minecraft/loot_table/entities/zombie.json
@@ -35,10 +35,6 @@
       "bonus_rolls": 0.0,
       "conditions": [
         {
-          "condition": "reference",
-          "name": "mobheads:should_head_drop"
-        },
-        {
           "condition": "minecraft:killed_by_player"
         },
         {
@@ -66,10 +62,6 @@
           "functions": [
             {
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:any_of",
                   "terms": [

--- a/data/minecraft/loot_table/entities/zombie.json
+++ b/data/minecraft/loot_table/entities/zombie.json
@@ -140,10 +140,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -165,10 +161,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -192,10 +184,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -217,10 +205,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -244,10 +228,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -269,10 +249,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/zombie_horse.json
+++ b/data/minecraft/loot_table/entities/zombie_horse.json
@@ -76,10 +76,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -101,10 +97,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -128,10 +120,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -153,10 +141,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -180,10 +164,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -205,10 +185,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/zombie_villager.json
+++ b/data/minecraft/loot_table/entities/zombie_villager.json
@@ -35,10 +35,6 @@
       "bonus_rolls": 0.0,
       "conditions": [
         {
-          "condition": "reference",
-          "name": "mobheads:should_head_drop"
-        },
-        {
           "condition": "minecraft:killed_by_player"
         },
         {
@@ -66,10 +62,6 @@
           "functions": [
             {
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:any_of",
                   "terms": [

--- a/data/minecraft/loot_table/entities/zombie_villager.json
+++ b/data/minecraft/loot_table/entities/zombie_villager.json
@@ -146,10 +146,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -171,10 +167,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -198,10 +190,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -223,10 +211,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -250,10 +234,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -275,10 +255,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -361,10 +337,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -386,10 +358,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -413,10 +381,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -438,10 +402,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -465,10 +425,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -490,10 +446,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -577,10 +529,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -602,10 +550,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -629,10 +573,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -654,10 +594,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -681,10 +617,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -706,10 +638,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -792,10 +720,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -817,10 +741,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -844,10 +764,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -869,10 +785,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -896,10 +808,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -921,10 +829,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1007,10 +911,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1032,10 +932,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1059,10 +955,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1084,10 +976,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1111,10 +999,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1136,10 +1020,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1222,10 +1102,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1247,10 +1123,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1274,10 +1146,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1299,10 +1167,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1326,10 +1190,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1351,10 +1211,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1437,10 +1293,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1462,10 +1314,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1489,10 +1337,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1514,10 +1358,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1541,10 +1381,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1566,10 +1402,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1652,10 +1484,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1677,10 +1505,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1704,10 +1528,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1729,10 +1549,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1756,10 +1572,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1781,10 +1593,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1867,10 +1675,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1892,10 +1696,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1919,10 +1719,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1944,10 +1740,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -1971,10 +1763,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -1996,10 +1784,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2082,10 +1866,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2107,10 +1887,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2134,10 +1910,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2159,10 +1931,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2186,10 +1954,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2211,10 +1975,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2297,10 +2057,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2322,10 +2078,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2349,10 +2101,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2374,10 +2122,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2401,10 +2145,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2426,10 +2166,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2512,10 +2248,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2537,10 +2269,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2564,10 +2292,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2589,10 +2313,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2616,10 +2336,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2641,10 +2357,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2727,10 +2439,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2752,10 +2460,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2779,10 +2483,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2804,10 +2504,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2831,10 +2527,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2856,10 +2548,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2942,10 +2630,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -2967,10 +2651,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -2994,10 +2674,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -3019,10 +2695,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -3046,10 +2718,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -3071,10 +2739,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -3157,10 +2821,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -3182,10 +2842,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -3209,10 +2865,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -3234,10 +2886,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -3261,10 +2909,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -3286,10 +2930,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -3372,10 +3012,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -3397,10 +3033,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -3424,10 +3056,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -3449,10 +3077,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -3476,10 +3100,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -3501,10 +3121,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -3587,10 +3203,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -3612,10 +3224,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -3639,10 +3247,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -3664,10 +3268,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -3691,10 +3291,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -3716,10 +3312,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -3803,10 +3395,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -3828,10 +3416,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -3855,10 +3439,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -3880,10 +3460,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -3907,10 +3483,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -3932,10 +3504,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4018,10 +3586,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -4043,10 +3607,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4070,10 +3630,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -4095,10 +3651,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4122,10 +3674,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -4147,10 +3695,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4233,10 +3777,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -4258,10 +3798,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4285,10 +3821,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -4310,10 +3842,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4337,10 +3865,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -4362,10 +3886,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4448,10 +3968,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -4473,10 +3989,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4500,10 +4012,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -4525,10 +4033,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4552,10 +4056,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -4577,10 +4077,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4663,10 +4159,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -4688,10 +4180,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4715,10 +4203,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -4740,10 +4224,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4767,10 +4247,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -4792,10 +4268,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4878,10 +4350,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -4903,10 +4371,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4930,10 +4394,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -4955,10 +4415,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -4982,10 +4438,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5007,10 +4459,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -5093,10 +4541,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5118,10 +4562,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -5145,10 +4585,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5170,10 +4606,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -5197,10 +4629,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5222,10 +4650,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -5308,10 +4732,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5333,10 +4753,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -5360,10 +4776,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5385,10 +4797,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -5412,10 +4820,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5437,10 +4841,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -5523,10 +4923,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5548,10 +4944,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -5575,10 +4967,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5600,10 +4988,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -5627,10 +5011,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5652,10 +5032,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -5738,10 +5114,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5763,10 +5135,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -5790,10 +5158,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5815,10 +5179,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -5842,10 +5202,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5867,10 +5223,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -5953,10 +5305,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -5978,10 +5326,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -6005,10 +5349,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -6030,10 +5370,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -6057,10 +5393,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -6082,10 +5414,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -6168,10 +5496,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -6193,10 +5517,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -6220,10 +5540,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -6245,10 +5561,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -6272,10 +5584,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -6297,10 +5605,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -6383,10 +5687,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -6408,10 +5708,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -6435,10 +5731,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -6460,10 +5752,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -6487,10 +5775,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -6512,10 +5796,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -6598,10 +5878,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -6623,10 +5899,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -6650,10 +5922,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -6675,10 +5943,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -6702,10 +5966,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -6727,10 +5987,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -6813,10 +6069,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -6838,10 +6090,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -6865,10 +6113,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -6890,10 +6134,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -6917,10 +6157,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -6942,10 +6178,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7029,10 +6261,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -7054,10 +6282,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7081,10 +6305,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -7106,10 +6326,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7133,10 +6349,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -7158,10 +6370,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7244,10 +6452,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -7269,10 +6473,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7296,10 +6496,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -7321,10 +6517,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7348,10 +6540,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -7373,10 +6561,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7459,10 +6643,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -7484,10 +6664,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7511,10 +6687,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -7536,10 +6708,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7563,10 +6731,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -7588,10 +6752,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7674,10 +6834,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -7699,10 +6855,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7726,10 +6878,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -7751,10 +6899,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7778,10 +6922,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -7803,10 +6943,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7889,10 +7025,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -7914,10 +7046,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7941,10 +7069,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -7966,10 +7090,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -7993,10 +7113,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8018,10 +7134,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -8104,10 +7216,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8129,10 +7237,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -8156,10 +7260,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8181,10 +7281,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -8208,10 +7304,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8233,10 +7325,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -8319,10 +7407,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8344,10 +7428,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -8371,10 +7451,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8396,10 +7472,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -8423,10 +7495,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8448,10 +7516,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -8534,10 +7598,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8559,10 +7619,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -8586,10 +7642,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8611,10 +7663,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -8638,10 +7686,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8663,10 +7707,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -8749,10 +7789,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8774,10 +7810,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -8801,10 +7833,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8826,10 +7854,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -8853,10 +7877,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8878,10 +7898,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -8964,10 +7980,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -8989,10 +8001,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -9016,10 +8024,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -9041,10 +8045,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -9068,10 +8068,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -9093,10 +8089,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -9179,10 +8171,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -9204,10 +8192,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -9231,10 +8215,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -9256,10 +8236,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -9283,10 +8259,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -9308,10 +8280,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -9394,10 +8362,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -9419,10 +8383,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -9446,10 +8406,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -9471,10 +8427,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -9498,10 +8450,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -9523,10 +8471,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -9609,10 +8553,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -9634,10 +8574,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -9661,10 +8597,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -9686,10 +8618,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -9713,10 +8641,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -9738,10 +8662,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -9824,10 +8744,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -9849,10 +8765,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -9876,10 +8788,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -9901,10 +8809,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -9928,10 +8832,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -9953,10 +8853,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -10039,10 +8935,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -10064,10 +8956,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -10091,10 +8979,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -10116,10 +9000,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -10143,10 +9023,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -10168,10 +9044,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -10255,10 +9127,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -10280,10 +9148,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -10307,10 +9171,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -10332,10 +9192,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -10359,10 +9215,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -10384,10 +9236,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -10470,10 +9318,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -10495,10 +9339,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -10522,10 +9362,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -10547,10 +9383,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -10574,10 +9406,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -10599,10 +9427,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -10685,10 +9509,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -10710,10 +9530,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -10737,10 +9553,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -10762,10 +9574,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -10789,10 +9597,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -10814,10 +9618,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -10900,10 +9700,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -10925,10 +9721,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -10952,10 +9744,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -10977,10 +9765,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11004,10 +9788,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -11029,10 +9809,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11115,10 +9891,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -11140,10 +9912,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11167,10 +9935,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -11192,10 +9956,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11219,10 +9979,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -11244,10 +10000,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11330,10 +10082,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -11355,10 +10103,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11382,10 +10126,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -11407,10 +10147,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11434,10 +10170,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -11459,10 +10191,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11545,10 +10273,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -11570,10 +10294,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11597,10 +10317,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -11622,10 +10338,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11649,10 +10361,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -11674,10 +10382,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11760,10 +10464,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -11785,10 +10485,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11812,10 +10508,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -11837,10 +10529,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11864,10 +10552,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -11889,10 +10573,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -11975,10 +10655,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -12000,10 +10676,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -12027,10 +10699,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -12052,10 +10720,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -12079,10 +10743,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -12104,10 +10764,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -12190,10 +10846,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -12215,10 +10867,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -12242,10 +10890,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -12267,10 +10911,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -12294,10 +10934,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -12319,10 +10955,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -12405,10 +11037,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -12430,10 +11058,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -12457,10 +11081,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -12482,10 +11102,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -12509,10 +11125,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -12534,10 +11146,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -12620,10 +11228,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -12645,10 +11249,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -12672,10 +11272,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -12697,10 +11293,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -12724,10 +11316,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -12749,10 +11337,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -12835,10 +11419,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -12860,10 +11440,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -12887,10 +11463,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -12912,10 +11484,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -12939,10 +11507,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -12964,10 +11528,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -13050,10 +11610,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -13075,10 +11631,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -13102,10 +11654,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -13127,10 +11675,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -13154,10 +11698,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -13179,10 +11719,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -13265,10 +11801,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -13290,10 +11822,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -13317,10 +11845,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -13342,10 +11866,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -13369,10 +11889,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -13394,10 +11910,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -13481,10 +11993,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -13506,10 +12014,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -13533,10 +12037,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -13558,10 +12058,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -13585,10 +12081,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -13610,10 +12102,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -13696,10 +12184,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -13721,10 +12205,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -13748,10 +12228,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -13773,10 +12249,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -13800,10 +12272,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -13825,10 +12293,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -13911,10 +12375,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -13936,10 +12396,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -13963,10 +12419,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -13988,10 +12440,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14015,10 +12463,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -14040,10 +12484,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14126,10 +12566,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -14151,10 +12587,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14178,10 +12610,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -14203,10 +12631,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14230,10 +12654,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -14255,10 +12675,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14341,10 +12757,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -14366,10 +12778,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14393,10 +12801,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -14418,10 +12822,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14445,10 +12845,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -14470,10 +12866,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14556,10 +12948,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -14581,10 +12969,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14608,10 +12992,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -14633,10 +13013,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14660,10 +13036,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -14685,10 +13057,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14771,10 +13139,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -14796,10 +13160,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14823,10 +13183,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -14848,10 +13204,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14875,10 +13227,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -14900,10 +13248,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -14986,10 +13330,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15011,10 +13351,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -15038,10 +13374,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15063,10 +13395,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -15090,10 +13418,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15115,10 +13439,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -15201,10 +13521,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15226,10 +13542,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -15253,10 +13565,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15278,10 +13586,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -15305,10 +13609,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15330,10 +13630,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -15416,10 +13712,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15441,10 +13733,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -15468,10 +13756,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15493,10 +13777,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -15520,10 +13800,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15545,10 +13821,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -15631,10 +13903,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15656,10 +13924,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -15683,10 +13947,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15708,10 +13968,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -15735,10 +13991,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15760,10 +14012,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -15846,10 +14094,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15871,10 +14115,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -15898,10 +14138,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15923,10 +14159,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -15950,10 +14182,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -15975,10 +14203,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -16061,10 +14285,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -16086,10 +14306,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -16113,10 +14329,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -16138,10 +14350,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -16165,10 +14373,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -16190,10 +14394,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -16276,10 +14476,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -16301,10 +14497,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -16328,10 +14520,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -16353,10 +14541,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -16380,10 +14564,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -16405,10 +14585,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -16491,10 +14667,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -16516,10 +14688,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -16543,10 +14711,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -16568,10 +14732,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -16595,10 +14755,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -16620,10 +14776,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -16707,10 +14859,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -16732,10 +14880,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -16759,10 +14903,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -16784,10 +14924,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -16811,10 +14947,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -16836,10 +14968,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -16922,10 +15050,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -16947,10 +15071,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -16974,10 +15094,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -16999,10 +15115,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17026,10 +15138,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -17051,10 +15159,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17137,10 +15241,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -17162,10 +15262,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17189,10 +15285,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -17214,10 +15306,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17241,10 +15329,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -17266,10 +15350,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17352,10 +15432,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -17377,10 +15453,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17404,10 +15476,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -17429,10 +15497,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17456,10 +15520,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -17481,10 +15541,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17567,10 +15623,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -17592,10 +15644,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17619,10 +15667,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -17644,10 +15688,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17671,10 +15711,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -17696,10 +15732,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17782,10 +15814,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -17807,10 +15835,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17834,10 +15858,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -17859,10 +15879,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17886,10 +15902,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -17911,10 +15923,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -17997,10 +16005,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18022,10 +16026,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -18049,10 +16049,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18074,10 +16070,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -18101,10 +16093,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18126,10 +16114,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -18212,10 +16196,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18237,10 +16217,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -18264,10 +16240,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18289,10 +16261,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -18316,10 +16284,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18341,10 +16305,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -18427,10 +16387,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18452,10 +16408,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -18479,10 +16431,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18504,10 +16452,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -18531,10 +16475,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18556,10 +16496,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -18642,10 +16578,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18667,10 +16599,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -18694,10 +16622,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18719,10 +16643,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -18746,10 +16666,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18771,10 +16687,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -18857,10 +16769,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18882,10 +16790,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -18909,10 +16813,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18934,10 +16834,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -18961,10 +16857,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -18986,10 +16878,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -19072,10 +16960,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -19097,10 +16981,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -19124,10 +17004,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -19149,10 +17025,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -19176,10 +17048,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -19201,10 +17069,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -19287,10 +17151,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -19312,10 +17172,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -19339,10 +17195,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -19364,10 +17216,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -19391,10 +17239,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -19416,10 +17260,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -19502,10 +17342,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -19527,10 +17363,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -19554,10 +17386,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -19579,10 +17407,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -19606,10 +17430,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -19631,10 +17451,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -19717,10 +17533,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -19742,10 +17554,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -19769,10 +17577,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -19794,10 +17598,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -19821,10 +17621,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -19846,10 +17642,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -19933,10 +17725,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -19958,10 +17746,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -19985,10 +17769,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -20010,10 +17790,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -20037,10 +17813,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -20062,10 +17834,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -20148,10 +17916,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -20173,10 +17937,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -20200,10 +17960,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -20225,10 +17981,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -20252,10 +18004,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -20277,10 +18025,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -20363,10 +18107,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -20388,10 +18128,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -20415,10 +18151,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -20440,10 +18172,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -20467,10 +18195,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -20492,10 +18216,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -20578,10 +18298,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -20603,10 +18319,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -20630,10 +18342,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -20655,10 +18363,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -20682,10 +18386,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -20707,10 +18407,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -20793,10 +18489,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -20818,10 +18510,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -20845,10 +18533,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -20870,10 +18554,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -20897,10 +18577,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -20922,10 +18598,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21008,10 +18680,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -21033,10 +18701,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21060,10 +18724,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -21085,10 +18745,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21112,10 +18768,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -21137,10 +18789,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21223,10 +18871,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -21248,10 +18892,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21275,10 +18915,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -21300,10 +18936,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21327,10 +18959,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -21352,10 +18980,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21438,10 +19062,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -21463,10 +19083,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21490,10 +19106,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -21515,10 +19127,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21542,10 +19150,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -21567,10 +19171,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21653,10 +19253,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -21678,10 +19274,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21705,10 +19297,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -21730,10 +19318,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21757,10 +19341,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -21782,10 +19362,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21868,10 +19444,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -21893,10 +19465,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21920,10 +19488,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -21945,10 +19509,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -21972,10 +19532,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -21997,10 +19553,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -22083,10 +19635,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -22108,10 +19656,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -22135,10 +19679,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -22160,10 +19700,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -22187,10 +19723,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -22212,10 +19744,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -22298,10 +19826,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -22323,10 +19847,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -22350,10 +19870,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -22375,10 +19891,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -22402,10 +19914,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -22427,10 +19935,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -22513,10 +20017,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -22538,10 +20038,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -22565,10 +20061,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -22590,10 +20082,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -22617,10 +20105,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -22642,10 +20126,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/zombified_piglin.json
+++ b/data/minecraft/loot_table/entities/zombified_piglin.json
@@ -131,10 +131,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -156,10 +152,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -183,10 +175,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -208,10 +196,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
@@ -235,10 +219,6 @@
               },
               "conditions": [
                 {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
-                {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",
                   "scores": {
@@ -260,10 +240,6 @@
                 ]
               },
               "conditions": [
-                {
-                  "condition": "reference",
-                  "name": "mobheads:should_head_drop"
-                },
                 {
                   "condition": "minecraft:entity_scores",
                   "entity": "attacker",

--- a/data/minecraft/loot_table/entities/zombified_piglin.json
+++ b/data/minecraft/loot_table/entities/zombified_piglin.json
@@ -65,10 +65,6 @@
       "bonus_rolls": 0.0,
       "conditions": [
         {
-          "condition": "reference",
-          "name": "mobheads:should_head_drop"
-        },
-        {
           "condition": "minecraft:killed_by_player"
         },
         {


### PR DESCRIPTION
When I did #6, I just did a global search and replace. Well, turns out I did thought it all the way through and accidentally applied the mob head condition to many things, even from vanilla loots

Nothing would breake when not using the predicate override feature from #6, but as soon as this predate will be `false`, it also disables a bunch of vanilla loots.

This PR removes the condition from all the places it isn't supposed to be in.